### PR TITLE
Add configuration helpers

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,17 @@
+import json
+import os
+
+from src.constants import ROOT_DIR
+
+
+def get_config():
+    """Load configuration from the project's config.json."""
+    config_path = os.path.join(ROOT_DIR, "config.json")
+
+    if not os.path.exists(config_path):
+        # If the configuration file is missing, return an empty dict
+        # so that modules depending on configuration can still initialize.
+        return {}
+
+    with open(config_path, "r") as f:
+        return json.load(f)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,19 @@
+import os
+
+# Constants for MoneyPrinterV2
+
+# Root directory of the repository
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Application version
+VERSION = "2.0.0"
+
+# Supported platforms for content generation/posting
+PLATFORMS = ["youtube", "twitter", "threads"]
+
+# Default content types by platform
+CONTENT_TYPES = {
+    "youtube": ["video", "shorts"],
+    "twitter": ["post", "thread"],
+    "threads": ["post", "carousel"],
+}


### PR DESCRIPTION
## Summary
- implement `src/constants.py` with `ROOT_DIR` and additional constants
- implement `src/config.py` with `get_config()` to read `config.json`

## Testing
- `pip install -r requirements.txt`
- `pip install openai`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'src.cache')*

------
https://chatgpt.com/codex/tasks/task_e_687c734422ec83318d653e6c7dd31409