### PR TITLE
Fix test imports and add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ MoneyPrinter is designed to be modular and extensible:
 ## Requirements
 
 - Python 3.6+
+- Install Python packages from `requirements.txt`
 - OpenAI API key
 - FFmpeg (for video generation)
 - Google API credentials (for Sheets integration)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ tweepy>=4.10.0
 facebook-sdk>=3.1.0
 schedule>=1.1.0
 python-dateutil>=2.8.2
+openai>=1.0.0
+gspread>=5.11.0
+oauth2client>=4.1.3
+dropbox>=11.36.2

--- a/tests/test_automation_process.py
+++ b/tests/test_automation_process.py
@@ -3,6 +3,10 @@ import sys
 import time
 import unittest
 from datetime import datetime
+
+# Add parent directory to path to import modules
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from src.news_automation_system import NewsAutomationSystem
 from src.automation_scheduler import AutomationScheduler
 from src.channel_manager import ChannelManager

--- a/tests/test_expanded_sns_integration.py
+++ b/tests/test_expanded_sns_integration.py
@@ -2,6 +2,11 @@ import unittest
 import os
 import json
 from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import modules
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from src.expanded_sns_connector import ExpandedSNSConnector
 from src.automated_posting_workflow import AutomatedPostingWorkflow
 from src.integrated_social_media_system import IntegratedSocialMediaSystem


### PR DESCRIPTION
## Summary
- update requirements with missing libraries
- remind users to install requirements
- fix tests' imports so modules resolve

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AttributeError in ChannelManager, missing API key, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_687c7cb7d970833197eb3ab0ceaa6ecd