### PR TITLE
Fix missing Flask dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ MoneyPrinter is a comprehensive automated content creation system designed to he
    ```
    pip install -r requirements.txt
    ```
+   This will install Flask and all other required packages.
 3. Set up API keys in the configuration file
 
 ### Configuration

--- a/docs/news_sns_uploader.md
+++ b/docs/news_sns_uploader.md
@@ -36,6 +36,8 @@ The system consists of four main components:
 pip install -r requirements.txt
 ```
 
+This command installs Flask along with the rest of the dependencies.
+
 3. Configure the system by creating a configuration file (see Configuration section)
 
 ## Configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ openai>=1.0.0
 gspread>=5.11.0
 oauth2client>=4.1.3
 dropbox>=11.36.2
+
+flask>=3.1.0


### PR DESCRIPTION
## Summary
- include Flask in requirements
- mention Flask installation in README
- clarify docs about installing dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: invalid OpenAI key)*

------
https://chatgpt.com/codex/tasks/task_e_687c80f99e888331b69df6b221e30c65